### PR TITLE
Support multi-file analyses and improve logging

### DIFF
--- a/src/glissade/glissade.py
+++ b/src/glissade/glissade.py
@@ -1,15 +1,16 @@
+import json
 import pandas as pd
 import numpy as np
-import re 
+import re
 import pickle
 import sys
 import argparse
-import warnings 
+import warnings
 import matplotlib.pyplot as plt
 from scipy.stats import binomtest
 
-from preprocessing import read_data, align_to_reference, seperate_scores
-from pava import alpha_minimize, mixture_sanity_check, _ecdf_on_grid
+from .preprocessing import read_data, align_to_reference, seperate_scores
+from .pava import alpha_minimize, mixture_sanity_check, _ecdf_on_grid
 
 def find_minima_sig(external_score_sample : np.array, matched_scores : np.array):
   """
@@ -149,20 +150,27 @@ def main():
   parser.add_argument("database_results")
   parser.add_argument("fasta_file")
   parser.add_argument("-n", "--n_bootstraps", type= int, default= 100, required=False, help="Number of bootstrap samples to perform")
+  parser.add_argument("--fdr", type=float, default=0.01, required=False, help="FDR threshold for database search results used for calibration (default: 0.01)")
   args = parser.parse_args(args=sys.argv[1:])
-  
+
   denovo_results = args.denovo_results
   database_results = args.database_results
   fasta_file = args.fasta_file
   n_bootstraps = args.n_bootstraps
 
-  print('Reading search results and aligning to reference...')
+  print('--- Reading input files ---')
   joined_df = read_data(database_results, denovo_results)
-  labeled_df = align_to_reference(joined_df, fasta_file)
+
+  print('--- Aligning to reference and applying FDR threshold ---')
+  labeled_df = align_to_reference(joined_df, fasta_file, database_fdr_threshold=args.fdr)
+
+  print('--- Collapsing to peptide level ---')
   matched_scores, external_scores, external_peps = seperate_scores(labeled_df)
-  print(f"Total matched scores: {len(matched_scores)}")
-  
-  print(f"Performing FDR control on {len(external_scores)} external peptides from de novo sequencing")
+
+  with open('glissade_stats.json', 'w') as f:
+    json.dump({'n_matched': len(matched_scores), 'n_external': len(external_scores)}, f)
+
+  print(f'--- Running FDR control on {len(external_scores)} external peptides using {len(matched_scores)} matched scores ---')
   fdrs, peps, scores = run_procedure(matched_scores, external_scores, external_peps, n_boots = 250)
   fdrs = compute_fdr_transform(fdrs)
   write_results(peps, fdrs, scores)
@@ -171,3 +179,6 @@ def main():
   # peptides, peptide_fdrs, scores = annotate_results(external_peps, external_scores, fdrs, grid)
   # peptide_fdrs = compute_fdr_transform(peptide_fdrs)
   # write_results(peptides, peptide_fdrs, scores)
+
+if __name__ == '__main__':
+  main()

--- a/src/glissade/preprocessing.py
+++ b/src/glissade/preprocessing.py
@@ -1,18 +1,19 @@
+import os
 import pandas as pd
 import numpy as np
-import re 
+import re
 import pickle
 import sys
 import argparse
-import warnings 
+import warnings
 import matplotlib.pyplot as plt
 
 warnings.filterwarnings("ignore")
 
 def read_data(db_file : str, denovo_file : str):
   """
-  Read in database search results and de novo results and join 
-  results on scan ID. 
+  Read in database search results and de novo results and join
+  results on (file_stem, scan) to support multi-file analyses.
 
   Parameters
   ----------
@@ -29,7 +30,6 @@ def read_data(db_file : str, denovo_file : str):
     db_scans = [int(x.split('_')[2]) for x in db_df['PSMId']]
     db_df['scan'] = db_scans
     # Use the filename column for file identity (supports multi-file analyses)
-    import os
     db_df['file_stem'] = db_df['filename'].apply(lambda x: os.path.splitext(os.path.basename(str(x)))[0])
   else:
     #FIXME handle other search results
@@ -46,8 +46,14 @@ def read_data(db_file : str, denovo_file : str):
           if m:
               run_map[m.group(1)] = os.path.splitext(os.path.basename(m.group(2).replace('file://', '').strip()))[0]
     denovo_df = pd.read_csv(denovo_file, sep='\t', skiprows=skiprows)
-    dn_scans = [int(x.split('scan=')[1].split('\t')[0]) for x in denovo_df['spectra_ref']]
-    dn_stems = [run_map.get(re.match(r'(ms_run\[\d+\])', x).group(1), '') for x in denovo_df['spectra_ref']]
+    def _parse_scan(ref):
+      m = re.search(r'scan=(\d+)', ref)
+      return int(m.group(1)) if m else None
+    def _parse_stem(ref):
+      m = re.match(r'(ms_run\[\d+\])', ref)
+      return run_map.get(m.group(1), '') if m else ''
+    dn_scans = [_parse_scan(x) for x in denovo_df['spectra_ref']]
+    dn_stems = [_parse_stem(x) for x in denovo_df['spectra_ref']]
     denovo_df['scan'] = dn_scans
     denovo_df['file_stem'] = dn_stems
     denovo_df = denovo_df.rename(columns={'search_engine_score[1]': 'denovo_score', 'sequence': 'denovo_peptide'})
@@ -94,15 +100,18 @@ def align_to_reference(results_df : pd.DataFrame, reference_file : str, database
   n_in_tide = sum(in_tide)
   print(f"  FDR threshold: {database_fdr_threshold}")
   n_total = len(results_df)
-  print(f"  Percolator PSMs passing FDR: {n_in_tide} / {n_total} ({100*n_in_tide/n_total:.1f}%)")
+  pct = f"{100*n_in_tide/n_total:.1f}%" if n_total > 0 else "N/A"
+  print(f"  Percolator PSMs passing FDR: {n_in_tide} / {n_total} ({pct})")
 
   db_peps = [''.join([i for i in re.sub(r'\[.*?\]', '', x[2:-2]) if i.isalpha()]).replace('I','L') for x in results_df['peptide']]
   denovo_peps = [''.join([i for i in re.sub(r'\[.*?\]', '', x) if i.isalpha()]).replace('I','L') for x in results_df['denovo_peptide']]
   agrees = [x == y for x,y in zip(db_peps, denovo_peps)]
   n_agrees = sum(agrees)
   n_both = sum(a and b for a, b in zip(in_tide, agrees))
-  print(f"  PSMs where Casanovo and Percolator agree: {n_agrees} / {n_total} ({100*n_agrees/n_total:.1f}%)")
-  print(f"  PSMs passing FDR and agreeing: {n_both} / {n_in_tide} ({100*n_both/n_in_tide:.1f}% of FDR-passing)")
+  pct_agrees = f"{100*n_agrees/n_total:.1f}%" if n_total > 0 else "N/A"
+  pct_both = f"{100*n_both/n_in_tide:.1f}%" if n_in_tide > 0 else "N/A"
+  print(f"  PSMs where Casanovo and Percolator agree: {n_agrees} / {n_total} ({pct_agrees})")
+  print(f"  PSMs passing FDR and agreeing: {n_both} / {n_in_tide} ({pct_both} of FDR-passing)")
 
   in_reference = [x in all_prots_string for x in denovo_peps]
 
@@ -140,16 +149,20 @@ def seperate_scores(labeled_df : pd.DataFrame, min_length : int = 8):
   matched_df = matched_df[matched_df['denovo_peptide'].apply(lambda x: len(x) >= min_length)]
   external_df = external_df[external_df['denovo_peptide'].apply(lambda x: len(x) >= min_length)]
 
-  print(f"  Matched PSMs after min_length={min_length} filter: {len(matched_df)} / {n_matched_raw} ({100*len(matched_df)/n_matched_raw:.1f}%)")
-  print(f"  External PSMs after min_length={min_length} filter: {len(external_df)} / {n_external_raw} ({100*len(external_df)/n_external_raw:.1f}%)")
+  n_matched_filt = len(matched_df)
+  n_external_filt = len(external_df)
+  pct_m = f"{100*n_matched_filt/n_matched_raw:.1f}%" if n_matched_raw > 0 else "N/A"
+  pct_e = f"{100*n_external_filt/n_external_raw:.1f}%" if n_external_raw > 0 else "N/A"
+  print(f"  Matched PSMs after min_length={min_length} filter: {n_matched_filt} / {n_matched_raw} ({pct_m})")
+  print(f"  External PSMs after min_length={min_length} filter: {n_external_filt} / {n_external_raw} ({pct_e})")
 
   matched_peps = matched_df.groupby('denovo_peptide')['denovo_score'].max()
   external_peps = external_df.groupby('denovo_peptide')['denovo_score'].max()
 
-  n_matched_filt = len(matched_df)
-  n_external_filt = len(external_df)
-  print(f"  Unique matched peptide sequences: {len(matched_peps)} / {n_matched_filt} ({100*len(matched_peps)/n_matched_filt:.1f}%)")
-  print(f"  Unique external peptide sequences: {len(external_peps)} / {n_external_filt} ({100*len(external_peps)/n_external_filt:.1f}%)")
+  pct_um = f"{100*len(matched_peps)/n_matched_filt:.1f}%" if n_matched_filt > 0 else "N/A"
+  pct_ue = f"{100*len(external_peps)/n_external_filt:.1f}%" if n_external_filt > 0 else "N/A"
+  print(f"  Unique matched peptide sequences: {len(matched_peps)} / {n_matched_filt} ({pct_um})")
+  print(f"  Unique external peptide sequences: {len(external_peps)} / {n_external_filt} ({pct_ue})")
 
   matched_scores =  np.log(matched_peps.values)
   external_scores =  np.log(external_peps.values)

--- a/src/glissade/preprocessing.py
+++ b/src/glissade/preprocessing.py
@@ -28,27 +28,41 @@ def read_data(db_file : str, denovo_file : str):
     db_df = pd.read_csv(db_file, sep='\t')
     db_scans = [int(x.split('_')[2]) for x in db_df['PSMId']]
     db_df['scan'] = db_scans
+    # Use the filename column for file identity (supports multi-file analyses)
+    import os
+    db_df['file_stem'] = db_df['filename'].apply(lambda x: os.path.splitext(os.path.basename(str(x)))[0])
   else:
     #FIXME handle other search results
     pass
 
   if '.mztab' in denovo_file:
+    # Build ms_run -> file stem mapping from MTD header
+    run_map = {}
     with open(denovo_file) as f_in:
       for skiprows, line in enumerate(f_in):
           if line.startswith("PSH"):
               break
+          m = re.match(r'MTD\s+(ms_run\[\d+\])-location\s+(.*)', line.strip())
+          if m:
+              run_map[m.group(1)] = os.path.splitext(os.path.basename(m.group(2).replace('file://', '').strip()))[0]
     denovo_df = pd.read_csv(denovo_file, sep='\t', skiprows=skiprows)
     dn_scans = [int(x.split('scan=')[1].split('\t')[0]) for x in denovo_df['spectra_ref']]
+    dn_stems = [run_map.get(re.match(r'(ms_run\[\d+\])', x).group(1), '') for x in denovo_df['spectra_ref']]
     denovo_df['scan'] = dn_scans
+    denovo_df['file_stem'] = dn_stems
     denovo_df = denovo_df.rename(columns={'search_engine_score[1]': 'denovo_score', 'sequence': 'denovo_peptide'})
 
   else:
     #FIXME handle other denovo result formats
     pass
 
-  joined_df = pd.merge(db_df, denovo_df, on='scan', how='inner')
+  print(f"  Percolator PSMs: {len(db_df)}")
+  print(f"  Casanovo PSMs:   {len(denovo_df)}")
+
+  joined_df = pd.merge(db_df, denovo_df, on=['file_stem', 'scan'], how='inner')
   joined_df.sort_values(by="denovo_score", ascending=False, inplace=True)
 
+  print(f"  PSMs after inner join on (file, scan): {len(joined_df)}")
   return joined_df
 
 def align_to_reference(results_df : pd.DataFrame, reference_file : str, database_fdr_threshold : float = 0.01):
@@ -77,10 +91,18 @@ def align_to_reference(results_df : pd.DataFrame, reference_file : str, database
           else:
               all_prots_string += '$'
   in_tide = [x < database_fdr_threshold for x in results_df['q-value']]
+  n_in_tide = sum(in_tide)
+  print(f"  FDR threshold: {database_fdr_threshold}")
+  n_total = len(results_df)
+  print(f"  Percolator PSMs passing FDR: {n_in_tide} / {n_total} ({100*n_in_tide/n_total:.1f}%)")
 
   db_peps = [''.join([i for i in re.sub(r'\[.*?\]', '', x[2:-2]) if i.isalpha()]).replace('I','L') for x in results_df['peptide']]
   denovo_peps = [''.join([i for i in re.sub(r'\[.*?\]', '', x) if i.isalpha()]).replace('I','L') for x in results_df['denovo_peptide']]
   agrees = [x == y for x,y in zip(db_peps, denovo_peps)]
+  n_agrees = sum(agrees)
+  n_both = sum(a and b for a, b in zip(in_tide, agrees))
+  print(f"  PSMs where Casanovo and Percolator agree: {n_agrees} / {n_total} ({100*n_agrees/n_total:.1f}%)")
+  print(f"  PSMs passing FDR and agreeing: {n_both} / {n_in_tide} ({100*n_both/n_in_tide:.1f}% of FDR-passing)")
 
   in_reference = [x in all_prots_string for x in denovo_peps]
 
@@ -110,11 +132,24 @@ def seperate_scores(labeled_df : pd.DataFrame, min_length : int = 8):
   matched_df = labeled_df[labeled_df['in_tide'] & labeled_df['agrees'] & (labeled_df['denovo_score'] > 0)]
   external_df = labeled_df[~labeled_df['in_tide'] & ~labeled_df['in_reference'] & (labeled_df['denovo_score'] > 0)]
 
+  n_matched_raw = len(matched_df)
+  n_external_raw = len(external_df)
+  print(f"  Matched PSMs (in_tide & agrees & score>0): {n_matched_raw}")
+  print(f"  External PSMs (not in_tide, not in_reference, score>0): {n_external_raw}")
+
   matched_df = matched_df[matched_df['denovo_peptide'].apply(lambda x: len(x) >= min_length)]
   external_df = external_df[external_df['denovo_peptide'].apply(lambda x: len(x) >= min_length)]
 
+  print(f"  Matched PSMs after min_length={min_length} filter: {len(matched_df)} / {n_matched_raw} ({100*len(matched_df)/n_matched_raw:.1f}%)")
+  print(f"  External PSMs after min_length={min_length} filter: {len(external_df)} / {n_external_raw} ({100*len(external_df)/n_external_raw:.1f}%)")
+
   matched_peps = matched_df.groupby('denovo_peptide')['denovo_score'].max()
   external_peps = external_df.groupby('denovo_peptide')['denovo_score'].max()
+
+  n_matched_filt = len(matched_df)
+  n_external_filt = len(external_df)
+  print(f"  Unique matched peptide sequences: {len(matched_peps)} / {n_matched_filt} ({100*len(matched_peps)/n_matched_filt:.1f}%)")
+  print(f"  Unique external peptide sequences: {len(external_peps)} / {n_external_filt} ({100*len(external_peps)/n_external_filt:.1f}%)")
 
   matched_scores =  np.log(matched_peps.values)
   external_scores =  np.log(external_peps.values)


### PR DESCRIPTION
## Summary

- **Fix multi-file join bug**: The join between Percolator and Casanovo results previously used scan number alone, which is not unique across files. Now joins on `(file_stem, scan)`, extracting the file stem from Percolator's `filename` column and from the mztab `MTD` header's `ms_run`-to-location mapping.
- **Fix peptide stripping with decimal modifications**: The old `x.split('.')` approach broke when modification masses contained decimal points (e.g. `Q[0.984]`), causing flanking residues to be included in the sequence. Fixed by using the `x[2:-2]` slice directly.
- **Add `--fdr` argument**: Allows the Percolator FDR threshold used for calibration to be set at the command line (default: 0.01).
- **Fix imports**: Changed bare `from preprocessing import ...` to relative `from .preprocessing import ...` so the package works correctly when invoked as `python -m glissade.glissade`.
- **Add `if __name__ == '__main__'` guard** and write `glissade_stats.json` with matched/external peptide counts.
- **Improve logging**: Report PSM counts from each input file, FDR pass rates, Casanovo/Percolator agreement rates, min-length filter retention, and unique-peptide collapse ratios at each step.

## Test plan

- [ ] Run on a multi-file dataset and verify the joined PSM count is correct (previously scan-number collisions inflated or deflated the join)
- [ ] Verify `--fdr 0.1` gives more matched calibration peptides than the default `--fdr 0.01`
- [ ] Check that `glissade_stats.json` is written with correct counts
- [ ] Confirm log output shows per-step PSM counts and percentages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable FDR threshold option to the command-line workflow.
  * Generated a summary stats file with match and score counts after processing.
  * Improved console progress messages to show each processing stage.

* **Bug Fixes**
  * Improved matching between input records to better handle denovo and database results.
  * Added a safer script entry point so the tool runs only when executed directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->